### PR TITLE
bin2c/concat: use standard methods for finding file sizes

### DIFF
--- a/src/bin2c/main.c
+++ b/src/bin2c/main.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <io.h>
 
 int main(int argc, char *argv[])
 {
@@ -45,7 +44,9 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	size = _filelength(_fileno(fp));
+    fseek(fp, 0, SEEK_END);
+	size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
 	if ((buf = malloc(size)) == NULL)
 	{
 

--- a/src/concat/main.c
+++ b/src/concat/main.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <io.h>
 
 unsigned char *read_file(const char *filename, long *size)
 {
@@ -31,7 +30,9 @@ unsigned char *read_file(const char *filename, long *size)
 		return NULL;
 	}
 
-	*size = _filelength(_fileno(fp));
+    fseek(fp, 0, SEEK_END);
+	*size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
 	if ((buf = malloc(*size)) == NULL)
 	{
 		printf("Error allocating buffer\n");


### PR DESCRIPTION
io.h doesn't seem to be standard. Builds under vanilla GCC with this change
